### PR TITLE
fix: Xcode 12 compatibility

### DIFF
--- a/react-native-ble-manager.podspec
+++ b/react-native-ble-manager.podspec
@@ -13,5 +13,5 @@ Pod::Spec.new do |s|
   s.source      	= { :git => "https://github.com/innoveit/react-native-ble-manager.git" }
   s.source_files	= "ios/**/*.{h,m}"
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
 end


### PR DESCRIPTION
Latest Xcode 12 fails to build while without a module to depend on `React-Core` directly hence this change is necessary for all native modules on iOS. For more details please check: [facebook/react-native#29633 (comment)](https://github.com/facebook/react-native/issues/29633#issuecomment-694187116)